### PR TITLE
Do not copy headers in the installation folder

### DIFF
--- a/aseba/common/CMakeLists.txt
+++ b/aseba/common/CMakeLists.txt
@@ -31,30 +31,6 @@ install(TARGETS asebacommon
 	ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
 )
 
-set (ASEBACORE_HDR_UTILS
-	utils/utils.h
-	utils/FormatableString.h
-)
-set (ASEBACORE_HDR_MSG
-	msg/msg.h
-	msg/NodesManager.h
-	msg/TargetDescription.h
-)
-set (ASEBACORE_HDR_COMMON
-	consts.h
-	types.h
-	productids.h
-)
-install(FILES ${ASEBACORE_HDR_UTILS}
-	DESTINATION include/aseba/common/utils
-)
-install(FILES ${ASEBACORE_HDR_MSG}
-	DESTINATION include/aseba/common/msg
-)
-install(FILES ${ASEBACORE_HDR_COMMON}
-	DESTINATION include/aseba/common
-)
-
 add_subdirectory(about)
 
 if(HAS_ZEROCONF_SUPPORT)

--- a/aseba/common/zeroconf/CMakeLists.txt
+++ b/aseba/common/zeroconf/CMakeLists.txt
@@ -15,15 +15,6 @@ install(TARGETS asebazeroconf
 	INCLUDES DESTINATION include/aseba/common/zeroconf
 )
 
-set (ASEBAZEROCONF_HDR
-	zeroconf.h
-	zeroconf-thread.h
-	zeroconf-dashelhub.h
-)
-install(FILES ${ASEBAZEROCONF_HDR}
-	DESTINATION include/aseba/common/zeroconf
-)
-
 # Zeroconf with Qt
 if (Qt5Network_FOUND)
 	set(CMAKE_AUTOMOC ON)
@@ -37,13 +28,6 @@ if (Qt5Network_FOUND)
 	install(TARGETS asebazeroconfqt
 		LIBRARY DESTINATION ${LIB_INSTALL_DIR}
 		ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
-	)
-
-	set (ASEBAZEROCONFQT_HDR
-		zeroconf-qt.h
-	)
-	install(FILES ${ASEBAZEROCONFQT_HDR}
-		DESTINATION include/aseba/common/zeroconf
 	)
 endif ()
 add_feature_info(QT_ZEROCONF Qt5Network_FOUND "Qt Zeroconf library ( depend on QtNetwork )")

--- a/aseba/compiler/CMakeLists.txt
+++ b/aseba/compiler/CMakeLists.txt
@@ -24,11 +24,3 @@ install(TARGETS asebacompiler
                 LIBRARY DESTINATION ${LIB_INSTALL_DIR} 
                 ARCHIVE DESTINATION ${LIB_INSTALL_DIR} 
 )
-
-set (ASEBACORE_HDR_COMPILER
-	compiler.h
-	errors_code.h
-)
-install(FILES ${ASEBACORE_HDR_COMPILER}
-	DESTINATION include/aseba/compiler
-)

--- a/aseba/switches/http/CMakeLists.txt
+++ b/aseba/switches/http/CMakeLists.txt
@@ -42,11 +42,4 @@ if (LIBXML2_FOUND)
 			ARCHIVE DESTINATION ${LIB_INSTALL_DIR} 
 	)
 
-	set (ASEBACORE_HDR_HTTP
-		http.h
-	)
-	install(FILES ${ASEBACORE_HDR_HTTP}
-		DESTINATION include/aseba/switches/http
-	)
-
 endif (LIBXML2_FOUND)

--- a/aseba/switches/http2/CMakeLists.txt
+++ b/aseba/switches/http2/CMakeLists.txt
@@ -29,18 +29,4 @@ if(LIBXML2_FOUND)
 			LIBRARY DESTINATION ${LIB_INSTALL_DIR} 
 			ARCHIVE DESTINATION ${LIB_INSTALL_DIR} 
 	)
-
-	set(ASEBACORE_HDR_HTTP2
-		AeslProgram.h
-		HttpDashelTarget.h
-		HttpHandler.h
-		HttpInterface.h
-		HttpInterfaceHandlers.h
-		HttpRequest.h
-		HttpResponse.h
-	)
-	
-	install(FILES ${ASEBACORE_HDR_HTTP2}
-		DESTINATION include/aseba/switches/http2
-	)
 endif(LIBXML2_FOUND)

--- a/aseba/transport/buffer/CMakeLists.txt
+++ b/aseba/transport/buffer/CMakeLists.txt
@@ -12,10 +12,3 @@ install(TARGETS asebavmbuffer
 
 target_link_libraries(asebavmbuffer asebavm)
 
-set (ASEBATRANSPORT_HDR_BUFFER
-	vm-buffer.h
-)
-install(FILES ${ASEBATRANSPORT_HDR_BUFFER}
-	DESTINATION include/aseba/transport/buffer
-)
-

--- a/aseba/transport/dashel_plugins/CMakeLists.txt
+++ b/aseba/transport/dashel_plugins/CMakeLists.txt
@@ -22,6 +22,3 @@ install(TARGETS asebadashelplugins
 		LIBRARY DESTINATION ${LIB_INSTALL_DIR} 
 		ARCHIVE DESTINATION ${LIB_INSTALL_DIR} 
 )
-install(FILES dashel-plugins.h
-	DESTINATION include/aseba/transport/dashel_plugins
-)

--- a/aseba/vm/CMakeLists.txt
+++ b/aseba/vm/CMakeLists.txt
@@ -15,11 +15,3 @@ install(TARGETS asebavm
                 ARCHIVE DESTINATION ${LIB_INSTALL_DIR} 
 )
 
-set (ASEBAVM_HDR_COMPILER
-	vm.h
-	natives.h
-)
-install(FILES ${ASEBAVM_HDR_COMPILER}
-	DESTINATION include/aseba/vm
-)
-


### PR DESCRIPTION
Aseba is more a set of tools than a frameworks.
We do not make ABI or API stability guarantees
except for some very specific classes.

Therefore we should not encourage people to use
aseba as libraries.

Modification, research works and new targets should rather
be added in-tree.