### PR TITLE
Implement TDM protocol versionning

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -91,6 +91,8 @@ before_build:
   - git submodule init
   - git submodule update --recursive --remote
   - git clone --depth 1 -b new_switch_api https://github.com/mobsya/thymio-blockly-standalone.git thymio-blockly-standalone --recurse-submodules
+  - if exist thymio-blockly-standalone\node_modules\ del thymio-blockly-standalone\node_modules\
+  - if exist js\node_modules\ del js\node_modules\
 
 build_script:
   - cd "%APPVEYOR_BUILD_FOLDER%"
@@ -126,7 +128,6 @@ cache:
   - C:\ProgramData\chocolatey\bin -> appveyor.yml
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
   - 'C:\Program Files (x86)\NSIS'
-  - '%APPDATA%\npm-cache'
 
 image: Visual Studio 2017
 platform: x64

--- a/aseba/flatbuffers/fb_message_ptr.h
+++ b/aseba/flatbuffers/fb_message_ptr.h
@@ -40,4 +40,14 @@ private:
     const fb::Message* m_msg;
 };
 
+template <typename MessageType>
+flatbuffers::DetachedBuffer wrap_fb(flatbuffers::FlatBufferBuilder& fb,
+                                    const flatbuffers::Offset<MessageType>& offset) {
+    auto rootOffset =
+        mobsya::fb::CreateMessage(fb, mobsya::fb::AnyMessageTraits<MessageType>::enum_value, offset.Union());
+    fb.Finish(rootOffset);
+    auto x = fb.ReleaseBufferPointer();
+    return x;
+}
+
 }  // namespace mobsya

--- a/aseba/flatbuffers/thymio.fbs
+++ b/aseba/flatbuffers/thymio.fbs
@@ -2,6 +2,12 @@
 
 namespace mobsya.fb;
 
+//Handshake messages
+table ConnectionHandshake {
+    minProtocolVersion:uint = 1;
+    protocolVersion:uint = 1;
+}
+
 ///A node id
 table NodeId {
    id:[ubyte];
@@ -151,6 +157,7 @@ table RequestCompleted {
 }
 
 union AnyMessage {
+    ConnectionHandshake,
     RequestListOfNodes,
     RequestNodeAsebaVMDescription,
     LockNode,

--- a/aseba/qt-thymio-dm-client-lib/thymio-api.h
+++ b/aseba/qt-thymio-dm-client-lib/thymio-api.h
@@ -2,10 +2,18 @@
 #include "thymiodevicemanagerclient.h"
 #include "thymionode.h"
 #include "thymiodevicesmodel.h"
-#include <QtQml/QtQml>
-
+#ifdef QT_QML_LIB
+#    include <QtQml/QtQml>
+#endif
 namespace mobsya {
+
+constexpr const unsigned protocolVersion = 1;
+constexpr const unsigned minProtocolVersion = 1;
+
+#ifdef QT_QML_LIB
 void register_qml_types() {
     qmlRegisterUncreatableType<mobsya::ThymioNode>("org.mobsya", 1, 0, "ThymioNode", "Enum");
 }
+#endif
+
 }  // namespace mobsya

--- a/aseba/qt-thymio-dm-client-lib/thymiodevicemanagerclient.cpp
+++ b/aseba/qt-thymio-dm-client-lib/thymiodevicemanagerclient.cpp
@@ -29,13 +29,9 @@ void ThymioDeviceManagerClient::onServiceAdded(QZeroConfService service) {
 
     else {
         QTcpSocket* socket = new QTcpSocket;
-        socket->connectToHost(service.host(), service.port());
-        if(!socket->waitForConnected(2000)) {
-            delete socket;
-            return;
-        }
         std::shared_ptr<ThymioDeviceManagerClientEndpoint> endpoint =
             std::make_shared<ThymioDeviceManagerClientEndpoint>(socket);
+        socket->connectToHost(service.host(), service.port());
 
         connect(endpoint.get(), &ThymioDeviceManagerClientEndpoint::onMessage, this,
                 &ThymioDeviceManagerClient::onMessage);

--- a/aseba/qt-thymio-dm-client-lib/thymiodevicemanagerclientendpoint.h
+++ b/aseba/qt-thymio-dm-client-lib/thymiodevicemanagerclientendpoint.h
@@ -12,6 +12,8 @@ public:
 
 private Q_SLOTS:
     void onReadyRead();
+    void onConnected();
+    void write(const flatbuffers::DetachedBuffer& buffer);
 
 Q_SIGNALS:
     void onMessage(const fb_message_ptr& msg);

--- a/aseba/switch/CMakeLists.txt
+++ b/aseba/switch/CMakeLists.txt
@@ -23,6 +23,7 @@ add_executable(switch
     node_id.h
     usb_utils.h
     utils.h
+    tdm.h
 )
 
 if(WIN32)

--- a/aseba/switch/flatbuffers_messages.h
+++ b/aseba/switch/flatbuffers_messages.h
@@ -4,19 +4,10 @@
 #include <flatbuffers/flatbuffers.h>
 #include "aseba_node.h"
 #include "aseba_node_registery.h"
+#include <aseba/flatbuffers/fb_message_ptr.h>
 
 namespace mobsya {
 
-
-template <typename MessageType>
-flatbuffers::DetachedBuffer wrap_fb(flatbuffers::FlatBufferBuilder& fb,
-                                    const flatbuffers::Offset<MessageType>& offset) {
-    auto rootOffset =
-        mobsya::fb::CreateMessage(fb, mobsya::fb::AnyMessageTraits<MessageType>::enum_value, offset.Union());
-    fb.Finish(rootOffset);
-    auto x = fb.ReleaseBufferPointer();
-    return x;
-}
 
 flatbuffers::DetachedBuffer create_nodes_list_request() {
     flatbuffers::FlatBufferBuilder fb;

--- a/aseba/switch/tdm.h
+++ b/aseba/switch/tdm.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace mobsya::tdm {
+constexpr const unsigned protocolVersion = 1;
+constexpr const unsigned minProtocolVersion = 1;
+}  // namespace mobsya::tdm

--- a/js/CMakeLists.txt
+++ b/js/CMakeLists.txt
@@ -17,7 +17,7 @@ set_property(TARGET thymio-js-api PROPERTY DEPENDS ${timestamp_file2})
 
 add_custom_command(
     OUTPUT  ${timestamp_file}
-    COMMAND ${NPM_EXECUTABLE} install
+    COMMAND ${NPM_EXECUTABLE} install --force
     COMMAND ${CMAKE_COMMAND} -E touch ${timestamp_file}
     COMMENT "thymio-js-api dependencies"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}

--- a/js/thymio_generated.js
+++ b/js/thymio_generated.js
@@ -88,18 +88,132 @@ mobsya.fb.ErrorType = {
  */
 mobsya.fb.AnyMessage = {
   NONE: 0,
-  RequestListOfNodes: 1,
-  RequestNodeAsebaVMDescription: 2,
-  LockNode: 3,
-  UnlockNode: 4,
-  RenameNode: 5,
-  RequestAsebaCodeLoad: 6,
-  RequestAsebaCodeRun: 7,
-  NodesChanged: 8,
-  NodeAsebaVMDescription: 9,
-  RequestCompleted: 10,
-  Error: 11,
-  CompilationError: 12
+  ConnectionHandshake: 1,
+  RequestListOfNodes: 2,
+  RequestNodeAsebaVMDescription: 3,
+  LockNode: 4,
+  UnlockNode: 5,
+  RenameNode: 6,
+  RequestAsebaCodeLoad: 7,
+  RequestAsebaCodeRun: 8,
+  NodesChanged: 9,
+  NodeAsebaVMDescription: 10,
+  RequestCompleted: 11,
+  Error: 12,
+  CompilationError: 13
+};
+
+/**
+ * @constructor
+ */
+mobsya.fb.ConnectionHandshake = function() {
+  /**
+   * @type {flatbuffers.ByteBuffer}
+   */
+  this.bb = null;
+
+  /**
+   * @type {number}
+   */
+  this.bb_pos = 0;
+};
+
+/**
+ * @param {number} i
+ * @param {flatbuffers.ByteBuffer} bb
+ * @returns {mobsya.fb.ConnectionHandshake}
+ */
+mobsya.fb.ConnectionHandshake.prototype.__init = function(i, bb) {
+  this.bb_pos = i;
+  this.bb = bb;
+  return this;
+};
+
+/**
+ * @param {flatbuffers.ByteBuffer} bb
+ * @param {mobsya.fb.ConnectionHandshake=} obj
+ * @returns {mobsya.fb.ConnectionHandshake}
+ */
+mobsya.fb.ConnectionHandshake.getRootAsConnectionHandshake = function(bb, obj) {
+  return (obj || new mobsya.fb.ConnectionHandshake).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+};
+
+/**
+ * @returns {number}
+ */
+mobsya.fb.ConnectionHandshake.prototype.minProtocolVersion = function() {
+  var offset = this.bb.__offset(this.bb_pos, 4);
+  return offset ? this.bb.readUint32(this.bb_pos + offset) : 1;
+};
+
+/**
+ * @param {number} value
+ * @returns {boolean}
+ */
+mobsya.fb.ConnectionHandshake.prototype.mutate_minProtocolVersion = function(value) {
+  var offset = this.bb.__offset(this.bb_pos, 4);
+
+  if (offset === 0) {
+    return false;
+  }
+
+  this.bb.writeUint32(this.bb_pos + offset, value);
+  return true;
+};
+
+/**
+ * @returns {number}
+ */
+mobsya.fb.ConnectionHandshake.prototype.protocolVersion = function() {
+  var offset = this.bb.__offset(this.bb_pos, 6);
+  return offset ? this.bb.readUint32(this.bb_pos + offset) : 1;
+};
+
+/**
+ * @param {number} value
+ * @returns {boolean}
+ */
+mobsya.fb.ConnectionHandshake.prototype.mutate_protocolVersion = function(value) {
+  var offset = this.bb.__offset(this.bb_pos, 6);
+
+  if (offset === 0) {
+    return false;
+  }
+
+  this.bb.writeUint32(this.bb_pos + offset, value);
+  return true;
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
+ */
+mobsya.fb.ConnectionHandshake.startConnectionHandshake = function(builder) {
+  builder.startObject(2);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
+ * @param {number} minProtocolVersion
+ */
+mobsya.fb.ConnectionHandshake.addMinProtocolVersion = function(builder, minProtocolVersion) {
+  builder.addFieldInt32(0, minProtocolVersion, 1);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
+ * @param {number} protocolVersion
+ */
+mobsya.fb.ConnectionHandshake.addProtocolVersion = function(builder, protocolVersion) {
+  builder.addFieldInt32(1, protocolVersion, 1);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
+ * @returns {flatbuffers.Offset}
+ */
+mobsya.fb.ConnectionHandshake.endConnectionHandshake = function(builder) {
+  var offset = builder.endObject();
+  return offset;
 };
 
 /**


### PR DESCRIPTION
When connecting to the TDM, a client *MUST* send a
`ConnectionHandshake` message which has 2 fields

* minProtocolVersion: the minimum protocol version supported by
the client
* protocolVersion:  the protocol version of the client

The server will respond with the same messages where

* minProtocolVersion: the minimum protocol version supported by
the server

* protocolVersion:  the protocol version selected by the server
for this session

* If the server respond with protocolVersion == 0,
the handshake failed and the connection is going to be closed.