### PR TITLE
[TDM] Advertise a maximum packet size

### DIFF
--- a/aseba/flatbuffers/thymio.fbs
+++ b/aseba/flatbuffers/thymio.fbs
@@ -3,9 +3,23 @@
 namespace mobsya.fb;
 
 //Handshake messages
+//The client needs to initiate the session by sending a ConnectionHandshake.
+//If the client sends a message before a ConnectionHandshake, the server will
+//drop the connection.
+//The server reply with the same message
 table ConnectionHandshake {
+    //In the server -> client direction, protocolVersion designs the version of the
+    //protocol both client and SERVER MUST use during the session
+    //If the protocolVersion sent by the server is 0, then the client and the server
+    //Do not share a compatible version, and the connection is dropped.
+    //minProtocolVersion designs the minimal protocol of the protocol supported by the sender
     minProtocolVersion:uint = 1;
     protocolVersion:uint = 1;
+
+    //Maximum size of a message
+    //Each endpoint must advertise the maximum size of message they will accept.
+    //If a message is received that exceed that size, the connection shall be dropped.
+    maxMessageSize:uint = 102400;
 }
 
 ///A node id

--- a/aseba/thymio-device-manager/tdm.h
+++ b/aseba/thymio-device-manager/tdm.h
@@ -3,4 +3,5 @@
 namespace mobsya::tdm {
 constexpr const unsigned protocolVersion = 1;
 constexpr const unsigned minProtocolVersion = 1;
+constexpr const unsigned maxAppEndPointMessageSize = 102400;  // 100k ought to be enough for anyone
 }  // namespace mobsya::tdm

--- a/js/thymio_generated.js
+++ b/js/thymio_generated.js
@@ -185,10 +185,33 @@ mobsya.fb.ConnectionHandshake.prototype.mutate_protocolVersion = function(value)
 };
 
 /**
+ * @returns {number}
+ */
+mobsya.fb.ConnectionHandshake.prototype.maxMessageSize = function() {
+  var offset = this.bb.__offset(this.bb_pos, 8);
+  return offset ? this.bb.readUint32(this.bb_pos + offset) : 102400;
+};
+
+/**
+ * @param {number} value
+ * @returns {boolean}
+ */
+mobsya.fb.ConnectionHandshake.prototype.mutate_maxMessageSize = function(value) {
+  var offset = this.bb.__offset(this.bb_pos, 8);
+
+  if (offset === 0) {
+    return false;
+  }
+
+  this.bb.writeUint32(this.bb_pos + offset, value);
+  return true;
+};
+
+/**
  * @param {flatbuffers.Builder} builder
  */
 mobsya.fb.ConnectionHandshake.startConnectionHandshake = function(builder) {
-  builder.startObject(2);
+  builder.startObject(3);
 };
 
 /**
@@ -205,6 +228,14 @@ mobsya.fb.ConnectionHandshake.addMinProtocolVersion = function(builder, minProto
  */
 mobsya.fb.ConnectionHandshake.addProtocolVersion = function(builder, protocolVersion) {
   builder.addFieldInt32(1, protocolVersion, 1);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
+ * @param {number} maxMessageSize
+ */
+mobsya.fb.ConnectionHandshake.addMaxMessageSize = function(builder, maxMessageSize) {
+  builder.addFieldInt32(2, maxMessageSize, 102400);
 };
 
 /**


### PR DESCRIPTION
This allow to protect against wrong actors and let embeded devices
allocate a single fixed size buffer.

Closes #246