### PR TITLE
[Aseba] More lenient protocol version check

### DIFF
--- a/aseba/clients/studio/DashelTarget.cpp
+++ b/aseba/clients/studio/DashelTarget.cpp
@@ -463,14 +463,14 @@ void DashelInterface::sendMessage(const Message& message) {
 void DashelInterface::nodeProtocolVersionMismatch(unsigned nodeId, const std::wstring& nodeName,
                                                   uint16_t protocolVersion) {
     // show a different warning in function of the mismatch
-    if(protocolVersion > ASEBA_PROTOCOL_VERSION) {
+    if(protocolVersion > ASEBA_MAX_TARGET_PROTOCOL_VERSION) {
         QMessageBox::warning(nullptr, QApplication::tr("Protocol version mismatch"),
                              QApplication::tr("Aseba Studio uses an older protocol (%1) than node "
                                               "%0 (%2), please upgrade Aseba Studio.")
                                  .arg(QString::fromStdWString(nodeName.c_str()))
                                  .arg(ASEBA_PROTOCOL_VERSION)
                                  .arg(protocolVersion));
-    } else if(protocolVersion < ASEBA_PROTOCOL_VERSION) {
+    } else if(protocolVersion < ASEBA_MIN_TARGET_PROTOCOL_VERSION) {
         QMessageBox::warning(nullptr, QApplication::tr("Protocol version mismatch"),
                              QApplication::tr("Node %0 uses an older protocol (%2) than Aseba "
                                               "Studio (%1), please upgrade the node firmware.")

--- a/aseba/common/consts.h
+++ b/aseba/common/consts.h
@@ -36,6 +36,9 @@ extern const char*  ASEBA_REVISION;
 /*! minimal accepted protocol version in targets */
 #define ASEBA_MIN_TARGET_PROTOCOL_VERSION 4
 
+/*! maximal accepted protocol version - this is an escape hatch if a breaking change happens !*/
+#define ASEBA_MAX_TARGET_PROTOCOL_VERSION 100
+
 /*! default listen target for aseba */
 #define ASEBA_DEFAULT_LISTEN_TARGET "tcpin:33333"
 

--- a/aseba/common/msg/NodesManager.cpp
+++ b/aseba/common/msg/NodesManager.cpp
@@ -115,7 +115,7 @@ void NodesManager::processMessage(const Message* message) {
 
             // Call a user function when a node protocol version mismatches
             if((description->protocolVersion < ASEBA_MIN_TARGET_PROTOCOL_VERSION) ||
-               (description->protocolVersion > ASEBA_PROTOCOL_VERSION)) {
+               (description->protocolVersion > ASEBA_MAX_TARGET_PROTOCOL_VERSION)) {
                 nodeProtocolVersionMismatch(description->source, description->name, description->protocolVersion);
                 mismatchingNodes.insert(description->source);
                 return;


### PR DESCRIPTION
Dashel based-clients required the exact same protocol
version for both the device and the client.

This is not sensible because it prevents
updating the firmwares independently of the client.

Instead the protocol should be backward compatible
with older endpoint (and protocols 5,6 and 7 are).

This patch provides and check against
ASEBA_MAX_TARGET_PROTOCOL_VERSION, which is an arbitrary value
should a non backward-compatible protocol change ever be needed.