### PR TITLE
Increase the delay before considering a node disconnected

### DIFF
--- a/aseba/thymio-device-manager/aseba_endpoint.h
+++ b/aseba/thymio-device-manager/aseba_endpoint.h
@@ -241,7 +241,7 @@ private:
             for(auto it = m_nodes.begin(); it != m_nodes.end();) {
                 const auto& info = it->second;
                 auto d = std::chrono::duration_cast<std::chrono::seconds>(now - info.last_seen);
-                if(d.count() >= 3) {
+                if(d.count() >= 10) {
                     mLogTrace("Node {} has been unresponsive for too long, disconnecting it!",
                               it->second.node->native_id());
                     info.node->set_status(aseba_node::status::disconnected);


### PR DESCRIPTION
Sending the vm description might take several seconds
which makes the whole network unresponsive in the
meantime