### PR TITLE
Send the description in fragments

### DIFF
--- a/aseba/common/consts.h
+++ b/aseba/common/consts.h
@@ -31,7 +31,7 @@ extern const char*  ASEBA_VERSION;
 extern const char*  ASEBA_REVISION;
 
 /*! version of aseba protocol, including bytecodes types and constants */
-#define ASEBA_PROTOCOL_VERSION 7
+#define ASEBA_PROTOCOL_VERSION 8
 
 /*! minimal accepted protocol version in targets */
 #define ASEBA_MIN_TARGET_PROTOCOL_VERSION 4
@@ -206,6 +206,7 @@ typedef enum
 	ASEBA_MESSAGE_GET_DEVICE_INFO,  // v6
 	ASEBA_MESSAGE_SET_DEVICE_INFO,  // v6
 	ASEBA_MESSAGE_GET_CHANGED_VARIABLES, // v7
+	ASEBA_MESSAGE_GET_NODE_DESCRIPTION_FRAGMENT, //v8
 
 	ASEBA_MESSAGE_INVALID = 0xFFFF
 } AsebaSystemMessagesTypes;

--- a/aseba/common/msg/msg.cpp
+++ b/aseba/common/msg/msg.cpp
@@ -517,6 +517,26 @@ bool operator==(const GetNodeDescription& lhs, const GetNodeDescription& rhs) {
     return static_cast<const CmdMessage&>(lhs) == static_cast<const CmdMessage&>(rhs) && lhs.version == rhs.version;
 }
 
+void GetNodeDescriptionFragment::serializeSpecific(SerializationBuffer& buffer) const {
+    CmdMessage::serializeSpecific(buffer);
+
+    buffer.add(version);
+    buffer.add(m_fragment);
+}
+
+void GetNodeDescriptionFragment::deserializeSpecific(SerializationBuffer& buffer) {
+    CmdMessage::deserializeSpecific(buffer);
+
+    version = buffer.get<uint16_t>();
+    m_fragment = buffer.get<int16_t>();
+}
+
+void GetNodeDescriptionFragment::dumpSpecific(wostream& stream) const {
+    CmdMessage::dumpSpecific(stream);
+
+    stream << "protocol version " << version;
+}
+
 //
 
 void Description::serializeSpecific(SerializationBuffer& buffer) const {

--- a/aseba/common/msg/msg.h
+++ b/aseba/common/msg/msg.h
@@ -293,6 +293,26 @@ protected:
 
 bool operator==(const GetNodeDescription& lhs, const GetNodeDescription& rhs);
 
+//! Request a specific node to send its description
+class GetNodeDescriptionFragment : public CmdMessage {
+public:
+    uint16_t version = ASEBA_PROTOCOL_VERSION;
+
+public:
+    GetNodeDescriptionFragment(int16_t fragment, uint16_t dest = ASEBA_DEST_INVALID)
+        : CmdMessage(ASEBA_MESSAGE_GET_NODE_DESCRIPTION_FRAGMENT, dest), m_fragment(fragment) {}
+
+protected:
+    void serializeSpecific(SerializationBuffer& buffer) const override;
+    void deserializeSpecific(SerializationBuffer& buffer) override;
+    void dumpSpecific(std::wostream&) const override;
+    operator const char*() const override {
+        return "get node description fragment";
+    }
+private:
+    int16_t m_fragment;
+};
+
 //! Description of a node, local events and native functions are omitted and further received by
 //! other messages
 class Description : public Message, public TargetDescription {

--- a/aseba/transport/buffer/vm-buffer.h
+++ b/aseba/transport/buffer/vm-buffer.h
@@ -66,6 +66,8 @@ extern uint16_t AsebaGetBuffer(AsebaVMState* vm, uint8_t* data, uint16_t maxLeng
 
 extern const AsebaVMDescription* AsebaGetVMDescription(AsebaVMState* vm);
 
+extern const AsebaVMDescription* AsebaGetVMDescriptionFragment(AsebaVMState* vm);
+
 extern const AsebaLocalEventDescription* AsebaGetLocalEventsDescriptions(AsebaVMState* vm);
 
 extern const AsebaNativeFunctionDescription* const* AsebaGetNativeFunctionsDescriptions(AsebaVMState* vm);

--- a/aseba/vm/vm.c
+++ b/aseba/vm/vm.c
@@ -803,6 +803,11 @@ void AsebaVMDebugMessage(AsebaVMState* vm, uint16_t id, uint16_t* data, uint16_t
 
         case ASEBA_MESSAGE_GET_NODE_DESCRIPTION: AsebaSendDescription(vm); break;
 
+        case ASEBA_MESSAGE_GET_NODE_DESCRIPTION_FRAGMENT: {
+            uint16_t version  = bswap16(data[0]);
+            int16_t  fragment = (int16_t)(bswap16(data[1]));
+            AsebaSendDescriptionFragment(vm, fragment); break;
+        }
         default: break;
     }
 }

--- a/aseba/vm/vm.h
+++ b/aseba/vm/vm.h
@@ -161,6 +161,9 @@ void AsebaSendChangedVariables(AsebaVMState* vm);
 /*! Called by AsebaVMDebugMessage when VM must send its description on the network. */
 void AsebaSendDescription(AsebaVMState* vm);
 
+/*! Called by AsebaVMDebugMessage when VM must send its description on the network. */
+void AsebaSendDescriptionFragment(AsebaVMState* vm, int16_t fragment);
+
 /*! Called by AsebaStep to perform a native function call. */
 void AsebaNativeFunction(AsebaVMState* vm, uint16_t id);
 

--- a/tests/compiler/asebavmdummycallbacks.cpp
+++ b/tests/compiler/asebavmdummycallbacks.cpp
@@ -66,6 +66,10 @@ extern "C" void AsebaSendDescription(AsebaVMState* vm) {
     std::cerr << "AsebaSendDescription" << std::endl;
 }
 
+extern "C" void AsebaSendDescriptionFragment(AsebaVMState* vm, int16_t fragment) {
+    std::cerr << "AsebaSendDescriptionFragment" << std::endl;
+}
+
 extern "C" void AsebaPutVmToSleep(AsebaVMState* vm) {
     std::cerr << "AsebaPutVmToSleep" << std::endl;
 }


### PR DESCRIPTION
New protocol version: 8

New message ASEBA_MESSAGE_GET_NODE_DESCRIPTION_FRAGMENT, ask the node
to split its description.

Fragment -1 is the general description (message Aseba::Description)
Fragments 0+ are the individual functions, events,
variables of the device.