### PR TITLE
When closing studio, send a shutdown message to the TDM.

### DIFF
--- a/aseba/flatbuffers/thymio.fbs
+++ b/aseba/flatbuffers/thymio.fbs
@@ -24,6 +24,14 @@ table ConnectionHandshake {
     //A token represented as a byte sequence.
     //Tokens are notably used to identify local clients and to give special permissions to applications
     token:[ubyte];
+
+    //In the server -> client direction, this is set to true if the client is on the same machine as the server
+    localhostPeer:bool = false;
+}
+
+//Stop the device manager
+table DeviceManagerShutdownRequest {
+    request_id:uint;
 }
 
 ///A node id
@@ -343,6 +351,7 @@ table EventsDescriptionsChanged {
 
 union AnyMessage {
     ConnectionHandshake,
+    DeviceManagerShutdownRequest,
     RequestListOfNodes,
     RequestNodeAsebaVMDescription,
     LockNode,

--- a/aseba/launcher/src/CMakeLists.txt
+++ b/aseba/launcher/src/CMakeLists.txt
@@ -22,6 +22,8 @@ add_executable(thymio-launcher WIN32
     main.cpp
     launcher.h
     launcher.cpp
+    launcherwindow.h
+    launcherwindow.cpp
     tdmsupervisor.h
     tdmsupervisor.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/launcher.rc

--- a/aseba/launcher/src/launcherwindow.cpp
+++ b/aseba/launcher/src/launcherwindow.cpp
@@ -1,0 +1,1 @@
+#include "launcherwindow.h"

--- a/aseba/launcher/src/launcherwindow.h
+++ b/aseba/launcher/src/launcherwindow.h
@@ -1,0 +1,20 @@
+#include <QQuickWidget>
+
+namespace mobsya {
+
+class LauncherWindow : public QQuickWidget {
+    Q_OBJECT
+public:
+    using QQuickWidget::QQuickWidget;
+Q_SIGNALS:
+    void closingRequested();
+
+
+protected:
+    void closeEvent(QCloseEvent* event) override {
+        event->accept();
+        Q_EMIT closingRequested();
+    }
+};
+
+}  // namespace mobsya

--- a/aseba/launcher/src/tdmsupervisor.cpp
+++ b/aseba/launcher/src/tdmsupervisor.cpp
@@ -13,12 +13,7 @@ TDMSupervisor::TDMSupervisor(const Launcher& launcher, QObject* parent)
     : QObject(parent), m_launcher(launcher), m_tdm_process(nullptr), m_launches(0) {}
 
 
-TDMSupervisor::~TDMSupervisor() {
-    stopTDM();
-    if(m_tdm_process) {
-        m_tdm_process->waitForFinished(500);
-    }
-}
+TDMSupervisor::~TDMSupervisor() {}
 
 void TDMSupervisor::startLocalTDM() {
     if(m_tdm_process != nullptr)
@@ -71,13 +66,5 @@ void TDMSupervisor::startLocalTDM() {
     // to split the path if it contains space
     m_tdm_process->start(path, QStringList{});
 }
-
-void TDMSupervisor::stopTDM() {
-    if(m_tdm_process) {
-        m_tdm_process->disconnect();
-        m_tdm_process->kill();
-    }
-}
-
 
 }  // namespace mobsya

--- a/aseba/launcher/src/tdmsupervisor.h
+++ b/aseba/launcher/src/tdmsupervisor.h
@@ -14,7 +14,6 @@ public:
 public Q_SLOTS:
 
     void startLocalTDM();
-    void stopTDM();
 
 Q_SIGNALS:
 

--- a/aseba/qt-thymio-dm-client-lib/thymiodevicemanagerclient.cpp
+++ b/aseba/qt-thymio-dm-client-lib/thymiodevicemanagerclient.cpp
@@ -93,5 +93,12 @@ void ThymioDeviceManagerClient::onEndpointDisconnected() {
     m_endpoints.erase(it);
 }
 
+void ThymioDeviceManagerClient::requestDeviceManagersShutdown() {
+    for(auto&& ep : m_endpoints.values()) {
+        if(ep && ep->isLocalhostPeer())
+            ep->requestDeviceManagerShutdown();
+    }
+}
+
 
 }  // namespace mobsya

--- a/aseba/qt-thymio-dm-client-lib/thymiodevicemanagerclient.h
+++ b/aseba/qt-thymio-dm-client-lib/thymiodevicemanagerclient.h
@@ -39,6 +39,8 @@ public:
         return ranges::view::all(m_nodes);
     }
 
+    void requestDeviceManagersShutdown();
+
 private Q_SLOTS:
     void onServiceAdded(QZeroConfService);
     void onServiceRemoved(QZeroConfService);

--- a/aseba/qt-thymio-dm-client-lib/thymiodevicemanagerclientendpoint.h
+++ b/aseba/qt-thymio-dm-client-lib/thymiodevicemanagerclientendpoint.h
@@ -22,6 +22,10 @@ public:
     QUrl websocketConnectionUrl() const;
     void setWebSocketMatchingPort(quint16 port);
 
+    bool isLocalhostPeer() const;
+    Request requestDeviceManagerShutdown();
+
+
     Request renameNode(const ThymioNode& node, const QString& newName);
     Request setNodeExecutionState(const ThymioNode& node, fb::VMExecutionStateCommand cmd);
     BreakpointsRequest setNodeBreakPoints(const ThymioNode& node, const QVector<unsigned>& breakpoints);
@@ -70,6 +74,7 @@ private:
     QTcpSocket* m_socket;
     quint32 m_message_size;
     quint16 m_ws_port = 0;
+    bool m_islocalhostPeer = false;
     QMap<detail::RequestDataBase::request_id, detail::RequestDataBase::shared_ptr> m_pending_requests;
 };
 

--- a/aseba/thymio-device-manager/app_endpoint.h
+++ b/aseba/thymio-device-manager/app_endpoint.h
@@ -182,6 +182,11 @@ public:
 
         mLogTrace("-> {}", EnumNameAnyMessage(msg.message_type()));
         switch(msg.message_type()) {
+            case mobsya::fb::AnyMessage::DeviceManagerShutdownRequest: {
+                if(m_local_endpoint)
+                    m_ctx.stop();
+                break;
+            }
             case mobsya::fb::AnyMessage::RequestListOfNodes: send_full_node_list(); break;
             case mobsya::fb::AnyMessage::RequestNodeAsebaVMDescription: {
                 auto req = msg.as<fb::RequestNodeAsebaVMDescription>();
@@ -727,7 +732,7 @@ private:
         flatbuffers::FlatBufferBuilder builder;
         write_message(wrap_fb(builder,
                               fb::CreateConnectionHandshake(builder, tdm::minProtocolVersion, m_protocol_version,
-                                                            tdm::maxAppEndPointMessageSize)));
+                                                            tdm::maxAppEndPointMessageSize, 0, m_local_endpoint)));
 
         // the client do not have a compatible protocol version, bailing out
         if(m_protocol_version == 0) {

--- a/js/thymio_generated.js
+++ b/js/thymio_generated.js
@@ -171,29 +171,30 @@ mobsya.fb.VMExecutionError = {
 mobsya.fb.AnyMessage = {
   NONE: 0, 0: 'NONE',
   ConnectionHandshake: 1, 1: 'ConnectionHandshake',
-  RequestListOfNodes: 2, 2: 'RequestListOfNodes',
-  RequestNodeAsebaVMDescription: 3, 3: 'RequestNodeAsebaVMDescription',
-  LockNode: 4, 4: 'LockNode',
-  UnlockNode: 5, 5: 'UnlockNode',
-  RenameNode: 6, 6: 'RenameNode',
-  CompileAndLoadCodeOnVM: 7, 7: 'CompileAndLoadCodeOnVM',
-  NodesChanged: 8, 8: 'NodesChanged',
-  NodeAsebaVMDescription: 9, 9: 'NodeAsebaVMDescription',
-  RequestCompleted: 10, 10: 'RequestCompleted',
-  Error: 11, 11: 'Error',
-  CompilationResultFailure: 12, 12: 'CompilationResultFailure',
-  CompilationResultSuccess: 13, 13: 'CompilationResultSuccess',
-  WatchNode: 14, 14: 'WatchNode',
-  VariablesChanged: 15, 15: 'VariablesChanged',
-  SetVariables: 16, 16: 'SetVariables',
-  EventsDescriptionsChanged: 17, 17: 'EventsDescriptionsChanged',
-  RegisterEvents: 18, 18: 'RegisterEvents',
-  SendEvents: 19, 19: 'SendEvents',
-  EventsEmitted: 20, 20: 'EventsEmitted',
-  SetBreakpoints: 21, 21: 'SetBreakpoints',
-  SetBreakpointsResponse: 22, 22: 'SetBreakpointsResponse',
-  SetVMExecutionState: 23, 23: 'SetVMExecutionState',
-  VMExecutionStateChanged: 24, 24: 'VMExecutionStateChanged'
+  DeviceManagerShutdownRequest: 2, 2: 'DeviceManagerShutdownRequest',
+  RequestListOfNodes: 3, 3: 'RequestListOfNodes',
+  RequestNodeAsebaVMDescription: 4, 4: 'RequestNodeAsebaVMDescription',
+  LockNode: 5, 5: 'LockNode',
+  UnlockNode: 6, 6: 'UnlockNode',
+  RenameNode: 7, 7: 'RenameNode',
+  CompileAndLoadCodeOnVM: 8, 8: 'CompileAndLoadCodeOnVM',
+  NodesChanged: 9, 9: 'NodesChanged',
+  NodeAsebaVMDescription: 10, 10: 'NodeAsebaVMDescription',
+  RequestCompleted: 11, 11: 'RequestCompleted',
+  Error: 12, 12: 'Error',
+  CompilationResultFailure: 13, 13: 'CompilationResultFailure',
+  CompilationResultSuccess: 14, 14: 'CompilationResultSuccess',
+  WatchNode: 15, 15: 'WatchNode',
+  VariablesChanged: 16, 16: 'VariablesChanged',
+  SetVariables: 17, 17: 'SetVariables',
+  EventsDescriptionsChanged: 18, 18: 'EventsDescriptionsChanged',
+  RegisterEvents: 19, 19: 'RegisterEvents',
+  SendEvents: 20, 20: 'SendEvents',
+  EventsEmitted: 21, 21: 'EventsEmitted',
+  SetBreakpoints: 22, 22: 'SetBreakpoints',
+  SetBreakpointsResponse: 23, 23: 'SetBreakpointsResponse',
+  SetVMExecutionState: 24, 24: 'SetVMExecutionState',
+  VMExecutionStateChanged: 25, 25: 'VMExecutionStateChanged'
 };
 
 /**
@@ -326,10 +327,33 @@ mobsya.fb.ConnectionHandshake.prototype.tokenArray = function() {
 };
 
 /**
+ * @returns {boolean}
+ */
+mobsya.fb.ConnectionHandshake.prototype.localhostPeer = function() {
+  var offset = this.bb.__offset(this.bb_pos, 12);
+  return offset ? !!this.bb.readInt8(this.bb_pos + offset) : false;
+};
+
+/**
+ * @param {boolean} value
+ * @returns {boolean}
+ */
+mobsya.fb.ConnectionHandshake.prototype.mutate_localhostPeer = function(value) {
+  var offset = this.bb.__offset(this.bb_pos, 12);
+
+  if (offset === 0) {
+    return false;
+  }
+
+  this.bb.writeInt8(this.bb_pos + offset, value);
+  return true;
+};
+
+/**
  * @param {flatbuffers.Builder} builder
  */
 mobsya.fb.ConnectionHandshake.startConnectionHandshake = function(builder) {
-  builder.startObject(4);
+  builder.startObject(5);
 };
 
 /**
@@ -387,9 +411,99 @@ mobsya.fb.ConnectionHandshake.startTokenVector = function(builder, numElems) {
 
 /**
  * @param {flatbuffers.Builder} builder
+ * @param {boolean} localhostPeer
+ */
+mobsya.fb.ConnectionHandshake.addLocalhostPeer = function(builder, localhostPeer) {
+  builder.addFieldInt8(4, +localhostPeer, +false);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
  * @returns {flatbuffers.Offset}
  */
 mobsya.fb.ConnectionHandshake.endConnectionHandshake = function(builder) {
+  var offset = builder.endObject();
+  return offset;
+};
+
+/**
+ * @constructor
+ */
+mobsya.fb.DeviceManagerShutdownRequest = function() {
+  /**
+   * @type {flatbuffers.ByteBuffer}
+   */
+  this.bb = null;
+
+  /**
+   * @type {number}
+   */
+  this.bb_pos = 0;
+};
+
+/**
+ * @param {number} i
+ * @param {flatbuffers.ByteBuffer} bb
+ * @returns {mobsya.fb.DeviceManagerShutdownRequest}
+ */
+mobsya.fb.DeviceManagerShutdownRequest.prototype.__init = function(i, bb) {
+  this.bb_pos = i;
+  this.bb = bb;
+  return this;
+};
+
+/**
+ * @param {flatbuffers.ByteBuffer} bb
+ * @param {mobsya.fb.DeviceManagerShutdownRequest=} obj
+ * @returns {mobsya.fb.DeviceManagerShutdownRequest}
+ */
+mobsya.fb.DeviceManagerShutdownRequest.getRootAsDeviceManagerShutdownRequest = function(bb, obj) {
+  return (obj || new mobsya.fb.DeviceManagerShutdownRequest).__init(bb.readInt32(bb.position()) + bb.position(), bb);
+};
+
+/**
+ * @returns {number}
+ */
+mobsya.fb.DeviceManagerShutdownRequest.prototype.requestId = function() {
+  var offset = this.bb.__offset(this.bb_pos, 4);
+  return offset ? this.bb.readUint32(this.bb_pos + offset) : 0;
+};
+
+/**
+ * @param {number} value
+ * @returns {boolean}
+ */
+mobsya.fb.DeviceManagerShutdownRequest.prototype.mutate_request_id = function(value) {
+  var offset = this.bb.__offset(this.bb_pos, 4);
+
+  if (offset === 0) {
+    return false;
+  }
+
+  this.bb.writeUint32(this.bb_pos + offset, value);
+  return true;
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
+ */
+mobsya.fb.DeviceManagerShutdownRequest.startDeviceManagerShutdownRequest = function(builder) {
+  builder.startObject(1);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
+ * @param {number} requestId
+ */
+mobsya.fb.DeviceManagerShutdownRequest.addRequestId = function(builder, requestId) {
+  builder.addFieldInt32(0, requestId, 0);
+};
+
+/**
+ * @param {flatbuffers.Builder} builder
+ * @returns {flatbuffers.Offset}
+ */
+mobsya.fb.DeviceManagerShutdownRequest.endDeviceManagerShutdownRequest = function(builder) {
   var offset = builder.endObject();
   return offset;
 };


### PR DESCRIPTION
Killing the TDM isn't nice an does not work
on windows depending on the installation directory.

Instead, when closing the launcher, it will send a
shutdown request to the localhost's TDM so that it
can shutdown cleanly.