### PR TITLE
[Launcher] Prevent unusable device to be selected

### DIFF
--- a/aseba/launcher/src/qml/Applications.qml
+++ b/aseba/launcher/src/qml/Applications.qml
@@ -54,9 +54,8 @@ ListModel {
         icon: "qrc:/apps/vpl/launcher-icon-vpl.svg"
         descriptionImage: "qrc:/apps/vpl/description.jpg"
         descriptionTextFile: "qrc:/apps/vpl/desc.en.html"
-
-
-
+        supportsGroups: false
+        supportsWatchMode: false
     }
     ListElement {
         appId: "scratch"
@@ -65,6 +64,8 @@ ListModel {
         icon: "qrc:/apps/scratch/launcher-icon-scratch.svg"
         descriptionImage: "qrc:/apps/scratch/description.jpg"
         descriptionTextFile: "qrc:/apps/scratch/desc.en.html"
+        supportsGroups: false
+        supportsWatchMode: false
     }
 
     ListElement {
@@ -74,6 +75,8 @@ ListModel {
         icon: "qrc:/apps/blockly/blockly-icon.svg"
         descriptionImage: "qrc:/apps/blockly/description.jpg"
         descriptionTextFile: "qrc:/apps/blockly/desc.en.html"
+        supportsGroups: false
+        supportsWatchMode: false
     }
 
      ListElement {
@@ -83,5 +86,7 @@ ListModel {
          icon: "qrc:/apps/studio/launcher-icon-studio.svg"
          descriptionImage: "qrc:/apps/studio/description.jpg"
          descriptionTextFile: "qrc:/apps/studio/desc.en.html"
+         supportsGroups: true
+         supportsWatchMode: true
      }
 }

--- a/aseba/qt-thymio-dm-client-lib/thymiodevicesmodel.cpp
+++ b/aseba/qt-thymio-dm-client-lib/thymiodevicesmodel.cpp
@@ -26,6 +26,7 @@ QVariant ThymioDevicesModel::data(const QModelIndex& index, int role) const {
         case NodeIdRole: return item->uuid().toString();
         case NodeTypeRole: return int(item->type());
         case NodeCapabilitiesRole: return quint64(item->capabilities());
+        case InGroupRole: return item->isInGroup();
         case Object: return QVariant::fromValue(item.get());
     }
     return {};
@@ -39,6 +40,7 @@ QHash<int, QByteArray> ThymioDevicesModel::roleNames() const {
     roles.insert(NodeTypeRole, "type");
     roles.insert(Object, "object");
     roles.insert(NodeCapabilitiesRole, "capabilities");
+    roles.insert(InGroupRole, "isInGroup");
     return roles;
 }
 

--- a/aseba/qt-thymio-dm-client-lib/thymiodevicesmodel.h
+++ b/aseba/qt-thymio-dm-client-lib/thymiodevicesmodel.h
@@ -10,7 +10,7 @@ class ThymioDeviceManagerClient;
 class ThymioDevicesModel : public QAbstractListModel {
     Q_OBJECT
 public:
-    enum Role { StatusRole = Qt::UserRole + 1, NodeIdRole, NodeTypeRole, NodeCapabilitiesRole, Object };
+    enum Role { StatusRole = Qt::UserRole + 1, NodeIdRole, NodeTypeRole, NodeCapabilitiesRole, InGroupRole, Object };
 
     ThymioDevicesModel(const ThymioDeviceManagerClient& manager, QObject* parent = nullptr);
     int rowCount(const QModelIndex& parent = QModelIndex()) const override;

--- a/aseba/qt-thymio-dm-client-lib/thymionode.h
+++ b/aseba/qt-thymio-dm-client-lib/thymionode.h
@@ -82,6 +82,7 @@ public:
     Q_PROPERTY(VMExecutionState vmExecutionState READ vmExecutionState NOTIFY vmExecutionStateChanged)
     Q_PROPERTY(NodeCapabilities capabilities READ capabilities NOTIFY capabilitiesChanged)
     Q_PROPERTY(NodeType type READ type CONSTANT)
+    Q_PROPERTY(bool isInGroup READ isInGroup NOTIFY groupChanged)
 
 
     ThymioNode(std::shared_ptr<ThymioDeviceManagerClientEndpoint>, const QUuid& uuid, const QString& name,
@@ -111,7 +112,9 @@ public:
     Status status() const;
     VMExecutionState vmExecutionState() const;
     NodeType type() const;
-    NodeCapabilities capabilities();
+    NodeCapabilities capabilities() const;
+    bool isInGroup() const;
+
     Q_INVOKABLE QUrl websocketEndpoint() const;
 
     void setGroup(std::shared_ptr<ThymioGroup> group);
@@ -214,6 +217,7 @@ public:
 
 Q_SIGNALS:
     void scratchPadChanged(const Scratchpad& scratchpad);
+    void groupChanged();
 
 private:
     void addNode(std::shared_ptr<ThymioNode>);


### PR DESCRIPTION
Unusable devices are:
 * Devices in a group if the application doesn't support that
 * Devices busy if the application doesn't support watch mode

Fixes #403