### PR TITLE
[TDM] Disconnect the old node when there are duplicated UUID.

### DIFF
--- a/aseba/thymio-device-manager/aseba_endpoint.h
+++ b/aseba/thymio-device-manager/aseba_endpoint.h
@@ -238,6 +238,17 @@ public:
         read_aseba_message();
     }
 
+    void remove_node(node_id n) {
+        for(auto it = m_nodes.begin(); it != m_nodes.end();) {
+            const auto& info = it->second;
+            if(info.node && info.node->uuid() == n) {
+                info.node->disconnect();
+                m_nodes.erase(it);
+                return;
+            }
+        }
+    }
+
 private:
     friend class aseba_node;
 

--- a/aseba/thymio-device-manager/aseba_node_registery.h
+++ b/aseba/thymio-device-manager/aseba_node_registery.h
@@ -35,6 +35,8 @@ public:
     std::shared_ptr<mobsya::group> group_from_id(const node_id&) const;
 
 private:
+    void remove_duplicated_node(const std::shared_ptr<aseba_node>& node);
+
     void save_group_affiliation(const aseba_node& node);
     void restore_group_affiliation(const aseba_node& node);
 


### PR DESCRIPTION
This allow us to deal with devices connected in
wireless and usb at the same time