### PR TITLE
[Qt API] Fix crash when an endpoint is disconnected.

### DIFF
--- a/aseba/qt-thymio-dm-client-lib/thymionode.cpp
+++ b/aseba/qt-thymio-dm-client-lib/thymionode.cpp
@@ -17,7 +17,7 @@ ThymioNode::ThymioNode(std::shared_ptr<ThymioDeviceManagerClientEndpoint> endpoi
     , m_executionState(VMExecutionState::Stopped)
     , m_type(type) {
 
-    connect(endpoint.get(), &ThymioDeviceManagerClientEndpoint::disconnected, [this] {
+    connect(endpoint.get(), &ThymioDeviceManagerClientEndpoint::disconnected, this, [this] {
         m_status = Status::Disconnected;
         Q_EMIT statusChanged();
     });


### PR DESCRIPTION
Fixes #440

A signal was attached to a lambda slot without an associated
object, causing the signat to be sent long after
the object has been destroyed.