### PR TITLE
Fix webview crash on OSX

### DIFF
--- a/aseba/launcher/src/qml/webview_native.qml
+++ b/aseba/launcher/src/qml/webview_native.qml
@@ -17,6 +17,8 @@ Window {
         window.show();
     }
     onClosing: {
+        webvView.loadHtml("<html></html>")
+        //webvView.stop()
         Qt.quit();
     }
 }


### PR DESCRIPTION
Load an empty webpage before destroying the webview
to avoid a crash on osx