### PR TITLE
[iOS] refresh bonjour service error message when app comes back from …

### DIFF
--- a/aseba/launcher/src/launcher.cpp
+++ b/aseba/launcher/src/launcher.cpp
@@ -280,6 +280,7 @@ Q_INVOKABLE void Launcher::applicationStateChanged(Qt::ApplicationState state) {
         // Fix the posisbility to reconnect from the thymio selection after the device sleeping, but does not provied
         // the browser to reconnect
         m_client->restartBrowser();
+        zeroconfStatusChanged();
     }
     lastState = state;
 }


### PR DESCRIPTION
They might be a better way to trig the zeroconfStatusChanged signal also when bonjour has restarted from the device manager client. 
fix #718