### PR TITLE
Defect#752 - boost 1.72 make a crash on macosx 10.12

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,4 +1,3 @@
-brew 'qt'
 brew 'ninja'
 brew 'cmake'
 brew 'ccache'

--- a/CMakeModules/cpp_features.cmake
+++ b/CMakeModules/cpp_features.cmake
@@ -25,3 +25,5 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
 endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-aligned-allocation")

--- a/CMakeModules/cpp_features.cmake
+++ b/CMakeModules/cpp_features.cmake
@@ -25,5 +25,3 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /permissive-")
 endif()
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-aligned-allocation")

--- a/aseba/launcher/src/launcher.cpp
+++ b/aseba/launcher/src/launcher.cpp
@@ -163,9 +163,9 @@ bool Launcher::openUrl(const QUrl& url) {
     // So, instead, defer to the system browser - which is more likely to work
     // because the version of safari shipped with an up-to-date Sierra is more current
     // than the system's webkit
-#ifdef Q_OS_OSX
+/*#ifdef Q_OS_OSX
     return openUrlWithParameters(url);
-#endif
+#endif*/
 
 #ifdef Q_OS_IOS
     OpenUrlInNativeWebView(url);

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,6 +198,11 @@ jobs:
     displayName: 'Extract scratch and blockly'
 
   - script: |
+      brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/224d82c09d0bbeda99b4ee9b5ccdf56773e5d513/Formula/qt.rb .
+      brew switch qt 5.13.2 .
+    displayName: 'Forcing Qt version to 5.13.2'
+
+  - script: |
       brew update
       brew bundle
     displayName: 'Install dependencies with HomeBrew'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -198,8 +198,8 @@ jobs:
     displayName: 'Extract scratch and blockly'
 
   - script: |
-      brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/224d82c09d0bbeda99b4ee9b5ccdf56773e5d513/Formula/qt.rb .
-      brew switch qt 5.13.2 .
+      brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/224d82c09d0bbeda99b4ee9b5ccdf56773e5d513/Formula/qt.rb 
+      brew switch qt 5.13.2 
     displayName: 'Forcing Qt version to 5.13.2'
 
   - script: |


### PR DESCRIPTION
the real issue is the version of Qt on the build machine. Automatically the version 5.14 is used, but this version is not compatible with macos 10.12