### PR TITLE
fixing compilation bug due to boost

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,7 @@ jobs:
       artifactName: 'thymio-suite.flatpak'
 
 - job: 'MSVC'
+  timeoutInMinutes: 90
   pool:
       vmImage: windows-2019
   strategy:
@@ -219,8 +220,8 @@ jobs:
 
   - script: |
       sudo xcode-select -s /Applications/Xcode_10.1.app/Contents/Developer
-      export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:$(brew --prefix qt)"
-      (mkdir build && cd build &&  cmake .. -GNinja -DBoost_DEBUG=ON -DOPENSSL_LIBRARIES=/usr/local/opt/openssl/lib -DOPENSSL_INCLUDE_DIR=/usr/local/opt/openssl/include -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF && ninja)
+      export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:$(brew --prefix qt):$(brew --prefix boost)"
+      (mkdir build && cd build &&  cmake .. -GNinja -DBoost_DEBUG=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && ninja)
     displayName: 'Build with cmake'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -225,7 +225,7 @@ jobs:
   - script: |
       sudo xcode-select -s /Applications/Xcode_10.1.app/Contents/Developer
       export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:$(brew --prefix qt)"
-      (mkdir build && cd build &&  cmake .. -GNinja -DBoost_DEBUG=OFF  -DOPENSSL_ROOT_DIR="/usr/local/Cellar/openssl/1.0.2j/" -DOPENSSL_LIBRARIES="/usr/local/Cellar/openssl/1.0.2j/lib" -DOPENSSL_INCLUDE_DIR="/usr/local/Cellar/openssl/1.0.2j/include" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && ninja)
+      (mkdir build && cd build &&  cmake .. -GNinja -DBoost_DEBUG=OFF  -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl/1.0.2j/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl/1.0.2j/lib -DOPENSSL_INCLUDE_DIR=/usr/local/Cellar/openssl/1.0.2j/include -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && ninja)
     displayName: 'Build with cmake'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -221,7 +221,7 @@ jobs:
   - script: |
       sudo xcode-select -s /Applications/Xcode_10.1.app/Contents/Developer
       export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:$(brew --prefix qt):$(brew --prefix boost)"
-      (mkdir build && cd build &&  cmake .. -GNinja -DBoost_DEBUG=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && ninja)
+      (mkdir build && cd build &&  cmake .. -GNinja -DBoost_DEBUG=OFF  -DOPENSSL_ROOT_DIR="/usr/local/Cellar/openssl@1.1/1.1.1d/" -DOPENSSL_LIBRARIES="/usr/local/Cellar/openssl@1.1/1.1.1d/lib" -DOPENSSL_INCLUDE_DIR="/usr/local/Cellar/openssl@1.1/1.1.1d/include -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && ninja)
     displayName: 'Build with cmake'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -225,7 +225,7 @@ jobs:
   - script: |
       sudo xcode-select -s /Applications/Xcode_10.1.app/Contents/Developer
       export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:$(brew --prefix qt)"
-      (mkdir build && cd build &&  cmake .. -GNinja -DBoost_DEBUG=OFF  -DOPENSSL_ROOT_DIR="/usr/local/Cellar/openssl/1.0.2j/" -DOPENSSL_LIBRARIES="/usr/local/Cellar/openssl/1.0.2j/lib" -DOPENSSL_INCLUDE_DIR="/usr/local/Cellar/openssl/1.0.2j/include -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && ninja)
+      (mkdir build && cd build &&  cmake .. -GNinja -DBoost_DEBUG=OFF  -DOPENSSL_ROOT_DIR="/usr/local/Cellar/openssl/1.0.2j/" -DOPENSSL_LIBRARIES="/usr/local/Cellar/openssl/1.0.2j/lib" -DOPENSSL_INCLUDE_DIR="/usr/local/Cellar/openssl/1.0.2j/include" -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && ninja)
     displayName: 'Build with cmake'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -210,6 +210,10 @@ jobs:
     displayName: 'Setting Boost version to 1.72.0'
 
   - script: |
+      brew install https://github.com/tebelorg/Tump/releases/download/v1.0.0/openssl.rb
+  displayName: 'Setting openssl version to 1.0.0'      
+
+  - script: |
       brew update
       brew bundle
     displayName: 'Install dependencies with HomeBrew'
@@ -220,8 +224,8 @@ jobs:
 
   - script: |
       sudo xcode-select -s /Applications/Xcode_10.1.app/Contents/Developer
-      export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:$(brew --prefix qt):$(brew --prefix boost)"
-      (mkdir build && cd build &&  cmake .. -GNinja -DBoost_DEBUG=OFF  -DOPENSSL_ROOT_DIR="/usr/local/Cellar/openssl@1.1/1.1.1d/" -DOPENSSL_LIBRARIES="/usr/local/Cellar/openssl@1.1/1.1.1d/lib" -DOPENSSL_INCLUDE_DIR="/usr/local/Cellar/openssl@1.1/1.1.1d/include -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && ninja)
+      export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:$(brew --prefix qt)"
+      (mkdir build && cd build &&  cmake .. -GNinja -DBoost_DEBUG=OFF  -DOPENSSL_ROOT_DIR="/usr/local/Cellar/openssl/1.0.2j/" -DOPENSSL_LIBRARIES="/usr/local/Cellar/openssl/1.0.2j/lib" -DOPENSSL_INCLUDE_DIR="/usr/local/Cellar/openssl/1.0.2j/include -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && ninja)
     displayName: 'Build with cmake'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,6 +211,7 @@ jobs:
 
   - script: |
       brew install https://github.com/tebelorg/Tump/releases/download/v1.0.0/openssl.rb
+      brew info openssl
     displayName: 'Setting openssl version to 1.0.0'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,7 +211,7 @@ jobs:
 
   - script: |
       brew install https://github.com/tebelorg/Tump/releases/download/v1.0.0/openssl.rb
-  displayName: 'Setting openssl version to 1.0.0'      
+    displayName: 'Setting openssl version to 1.0.0'
 
   - script: |
       brew update
@@ -225,7 +225,7 @@ jobs:
   - script: |
       sudo xcode-select -s /Applications/Xcode_10.1.app/Contents/Developer
       export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:$(brew --prefix qt)"
-      (mkdir build && cd build &&  cmake .. -GNinja -DBoost_DEBUG=OFF  -DOPENSSL_ROOT_DIR=/usr/local/Cellar/openssl/1.0.2j/ -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl/1.0.2j/lib -DOPENSSL_INCLUDE_DIR=/usr/local/Cellar/openssl/1.0.2j/include -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && ninja)
+      (mkdir build && cd build &&  cmake .. -GNinja -DBoost_DEBUG=OFF -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl/1.0.2j/lib -DOPENSSL_INCLUDE_DIR=/usr/local/Cellar/openssl/1.0.2j/include -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && ninja)
     displayName: 'Build with cmake'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -210,7 +210,7 @@ jobs:
     displayName: 'Setting Boost version to 1.72.0'
 
   - script: |
-      brew install https://github.com/tebelorg/Tump/releases/download/v1.0.0/openssl.rb
+      brew uninstall openssl; brew uninstall openssl; brew install https://github.com/tebelorg/Tump/releases/download/v1.0.0/openssl.rb
       brew info openssl
     displayName: 'Setting openssl version to 1.0.0'
 
@@ -226,7 +226,7 @@ jobs:
   - script: |
       sudo xcode-select -s /Applications/Xcode_10.1.app/Contents/Developer
       export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH}:$(brew --prefix qt)"
-      (mkdir build && cd build &&  cmake .. -GNinja -DBoost_DEBUG=OFF -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl/1.0.2j/lib -DOPENSSL_INCLUDE_DIR=/usr/local/Cellar/openssl/1.0.2j/include -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && ninja)
+      (mkdir build && cd build &&  cmake .. -GNinja -DBoost_DEBUG=OFF -DOPENSSL_LIBRARIES=/usr/local/Cellar/openssl/1.0.2t/lib -DOPENSSL_INCLUDE_DIR=/usr/local/Cellar/openssl/1.0.2t/include -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF && ninja)
     displayName: 'Build with cmake'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -201,7 +201,12 @@ jobs:
   - script: |
       brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/224d82c09d0bbeda99b4ee9b5ccdf56773e5d513/Formula/qt.rb 
       brew switch qt 5.13.2 
-    displayName: 'Forcing Qt version to 5.13.2'
+    displayName: 'Setting Qt version to 5.13.2'
+
+  - script: |
+      brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/ae73ba09216a7f8b2c0503e57221db020bcd3471/Formula/boost.rb
+      brew switch boost 1.72.0
+    displayName: 'Setting Boost version to 1.72.0'
 
   - script: |
       brew update


### PR DESCRIPTION
Pointing the specific version of boost
as 1.72.0
in order to be compliant with mac_os 10.14 specific to the latest build machine configuration

The mod is obtained by the azure_pipeline custom homebrew callout