### PR TITLE
Improve zero conf announce reliability.

### DIFF
--- a/aseba/thymio-device-manager/aseba_node_registery.h
+++ b/aseba/thymio-device-manager/aseba_node_registery.h
@@ -30,7 +30,7 @@ public:
 
     void set_tcp_endpoint(const boost::asio::ip::tcp::endpoint& endpoint);
     void set_ws_endpoint(const boost::asio::ip::tcp::endpoint& endpoint);
-	void set_discovery();
+    void announce_on_zeroconf();
 
     node_map nodes() const;
     std::shared_ptr<aseba_node> node_from_id(const node_id&) const;
@@ -48,8 +48,8 @@ private:
     void save_group_affiliation(const aseba_node& node);
     void restore_group_affiliation(const aseba_node& node);
 
-    void update_discovery();
-    void on_update_discovery_complete(const boost::system::error_code&);
+    void do_announce_on_zeroconf();
+    void on_announce_complete(const boost::system::error_code&);
     aware::contact::property_map_type build_discovery_properties() const;
 
     node_map::const_iterator find(const std::shared_ptr<aseba_node>& node) const;
@@ -72,9 +72,6 @@ private:
     aware::contact m_nodes_service_desc;
     // Endpoint of the WebSocket - So we can expose the port on zeroconf
     boost::asio::ip::tcp::endpoint m_ws_endpoint;
-
-    bool m_updating_discovery = false;
-    bool m_discovery_needs_update = false;
 
     boost::signals2::signal<void(std::shared_ptr<aseba_node>, node_id, aseba_node::status)>
         m_node_status_changed_signal;

--- a/aseba/thymio-device-manager/main.cpp
+++ b/aseba/thymio-device-manager/main.cpp
@@ -50,25 +50,18 @@ void run_service(boost::asio::io_context& ctx) {
 
     [[maybe_unused]] mobsya::wireless_configurator_service& ws =
         boost::asio::make_service<mobsya::wireless_configurator_service>(ctx);
-    // ws.enable();
+    ws.enable();
 
     // Create a server for regular tcp connection
     mobsya::application_server<mobsya::tcp::socket> tcp_server(ctx, 0);
     node_registery.set_tcp_endpoint(tcp_server.endpoint());
-    tcp_server.accept();
    
     mobsya::aseba_tcp_acceptor aseba_tcp_acceptor(ctx);
 
     // Create a server for websocket
     mobsya::application_server<mobsya::websocket_t> websocket_server(ctx, 8597);
 	node_registery.set_ws_endpoint(websocket_server.endpoint());
-    websocket_server.accept();
-
-    // Enable Bonjour, Zeroconf 
-	node_registery.set_discovery();
     
-    mLogTrace("=> TCP Server connected on {}", tcp_server.endpoint().port());
-    mLogTrace("=> WS Server connected on {}", websocket_server.endpoint().port());
 
 #ifdef MOBSYA_TDM_ENABLE_USB
     mobsya::usb_server usb_server(ctx, {mobsya::THYMIO2_DEVICE_ID, mobsya::THYMIO_WIRELESS_DEVICE_ID});
@@ -79,6 +72,16 @@ void run_service(boost::asio::io_context& ctx) {
     serial_server.accept();
 #endif
     aseba_tcp_acceptor.accept();
+    websocket_server.accept();
+    tcp_server.accept();
+
+    mLogTrace("=> TCP Server started on {}", tcp_server.endpoint().port());
+    mLogTrace("=> WS Server started on {}", websocket_server.endpoint().port());
+
+    // Enable Bonjour/Zeroconf
+    // Make sure this is done after the different servers are started and accept connections
+    // So that clients can connect to discovered services
+    node_registery.announce_on_zeroconf();
 
     ctx.run();
 }


### PR DESCRIPTION
* Make sure the even loop was entered before trying to announce
the TDM on zeroconf.

* Make sure the server are accepting connections by the TDM is
announced on zero conf.

* Refresh the announce every few seconds in case there
was some spurious failure.

This changes should make zero conf a bit more reliable and
avoid some of the issues where the launcher doesn't see the
TDM



I have spend a significant amount of time trying to find race conditions, undefined behavior and so forth and I am not seeing anything abnormal.
I have compared aware with other zero conf implementations ( notably the one used by the launcher) and I'm not seeing anything weird.
There was an issue where we  could try to announce on zero conf before the client was started if the event loop had not been started yet. I am assuming this was the culprit. 

This patch should allow the TDM to announce itself if for some reason (which i was not able to really reproduce), it fails the first time.


This, along with further patches to enable direct connection to local TDM will hopefully reduce the number of issues observed by users